### PR TITLE
Misc appimage build fixes

### DIFF
--- a/.github/workflows/appimage-creation.yml
+++ b/.github/workflows/appimage-creation.yml
@@ -69,7 +69,7 @@ jobs:
         openSpaceHome="$HOME/source/OpenSpace"
         cd "$openSpaceHome/build"
         # Use the system's libvulkan, not the vendored one, otherwise they might conflict
-        cef_orig_dir=$(find $HOME/source/OpenSpace/build -name libcef.so | xargs dirname)
+        cef_orig_dir=$(find $HOME/source/OpenSpace/build -path */Release/libcef.so | xargs dirname)
         rm -v $cef_orig_dir/libvulkan.so.1
         make -j 3
         
@@ -104,6 +104,12 @@ jobs:
         # ./appimagetool-*.AppImage -s deploy appdir/usr/share/applications/*.desktop # Bundle EVERYTHING
         # or 
         ./appimagetool-*.AppImage deploy appdir/usr/share/applications/*.desktop # Bundle everything except what comes with the base system
+
+        # Install libcef runtime dependencies (the "deploy" step has automatically found libcef.so
+        # thanks to dynamic linking information but can't guess some other dependencies)
+        cef_orig_dir=$(find $HOME/source/OpenSpace/build -path */Release/libcef.so | xargs dirname)
+        cef_install_dir=$(find ./appdir -name libcef.so | xargs dirname)
+        cp -r $cef_orig_dir/* $cef_install_dir
 
         # turn AppDir into AppImage
         VERSION=0.20.1p_wot_wolibv ./appimagetool-*.AppImage ./appdir

--- a/.github/workflows/appimage-creation.yml
+++ b/.github/workflows/appimage-creation.yml
@@ -68,6 +68,9 @@ jobs:
       run: |
         openSpaceHome="$HOME/source/OpenSpace"
         cd "$openSpaceHome/build"
+        # Use the system's libvulkan, not the vendored one, otherwise they might conflict
+        cef_orig_dir=$(find $HOME/source/OpenSpace/build -name libcef.so | xargs dirname)
+        rm -v $cef_orig_dir/libvulkan.so.1
         make -j 3
         
     - name: Create appimage
@@ -101,11 +104,6 @@ jobs:
         # ./appimagetool-*.AppImage -s deploy appdir/usr/share/applications/*.desktop # Bundle EVERYTHING
         # or 
         ./appimagetool-*.AppImage deploy appdir/usr/share/applications/*.desktop # Bundle everything except what comes with the base system
-
-        # trying to fix issue #1
-        rm -v appdir/home/runner/source/OpenSpace/build/modules/webbrowser/ext/cef/cef_binary_102.0.10+gf249b2e+chromium-102.0.5005.115_linux64/Release/libvulkan.so.1
-        echo "Check if libvulkan.so.1 files have been excluded  ... "
-        find ./appdir -name libvulkan.so.1 
 
         # turn AppDir into AppImage
         VERSION=0.20.1p_wot_wolibv ./appimagetool-*.AppImage ./appdir

--- a/.github/workflows/appimage-creation.yml
+++ b/.github/workflows/appimage-creation.yml
@@ -101,6 +101,8 @@ jobs:
         wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases/expanded_assets/continuous -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
         chmod +x appimagetool-*.AppImage
 
+        # If you ever get an issue with appimage bundling the wrong Qt version,
+        # try setting the  QTDIR env var (cf. https://github.com/probonopd/go-appimage/issues/268)
         # ./appimagetool-*.AppImage -s deploy appdir/usr/share/applications/*.desktop # Bundle EVERYTHING
         # or 
         ./appimagetool-*.AppImage deploy appdir/usr/share/applications/*.desktop # Bundle everything except what comes with the base system

--- a/.github/workflows/appimage-creation.yml
+++ b/.github/workflows/appimage-creation.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         openSpaceHome="$HOME/source/OpenSpace"
         cd "$openSpaceHome/build"
-        cmake -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/g++-13 -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/gcc-13 -DCMAKE_CXX_STANDARD=20 -DASSIMP_BUILD_MINIZIP=1 -DBUILD_TESTS=OFF "$openSpaceHome"
+        cmake -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/g++-13 -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/gcc-13 -DCMAKE_CXX_STANDARD=20 -DASSIMP_BUILD_MINIZIP=1 -DBUILD_TESTS=OFF -DOPENSPACE_HAVE_TESTS=OFF -DSGCT_BUILD_TESTS=OFF "$openSpaceHome"
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/appimage-creation.yml
+++ b/.github/workflows/appimage-creation.yml
@@ -85,7 +85,7 @@ jobs:
         mkdir -p appdir/usr/share/icons/hicolor/256x256/apps ; cp ./appdir/OpenSpace.png ./appdir/usr/share/icons/hicolor/256x256/apps/
 
         # The OpenSpace executable expects these files in the parent directory of its bin directory
-        cp -r $HOME/source/OpenSpace/{config/,modules/,data/,scripts/,shaders/,openspace.cfg} ./appdir/usr/
+        cp -r $HOME/source/OpenSpace/{config/,modules/,data/,scripts/,shaders,/documentation/,openspace.cfg} ./appdir/usr/
 
         # patch file created with diff -u openspace.cfg openspace.edited
         patch ./appdir/usr/openspace.cfg < ./appdir/openspacecfg.patch

--- a/.github/workflows/appimage-creation.yml
+++ b/.github/workflows/appimage-creation.yml
@@ -71,7 +71,7 @@ jobs:
         # Use the system's libvulkan, not the vendored one, otherwise they might conflict
         cef_orig_dir=$(find $HOME/source/OpenSpace/build -path */Release/libcef.so | xargs dirname)
         rm -v $cef_orig_dir/libvulkan.so.1
-        make -j 3
+        make -j $(nproc)
         
     - name: Create appimage
       working-directory: ${{github.workspace}}

--- a/.github/workflows/appimage-creation.yml
+++ b/.github/workflows/appimage-creation.yml
@@ -83,7 +83,7 @@ jobs:
         # The OpenSpace executable expects these files in the parent directory of its bin directory
         cp -r $HOME/source/OpenSpace/{config/,modules/,data/,scripts/,shaders/,openspace.cfg} ./appdir/usr/
         # patch file created with diff -u openspace.cfg openspace.edited
-        patch -u $HOME/source/OpenSpace/openspace.cfg ./appdir/openspacecfg.patch
+        patch ./appdir/usr/openspace.cfg < ./appdir/openspacecfg.patch
         # https://stackoverflow.com/questionopenspace.cfgs/43412885/fastest-way-to-delete-files-from-a-directory-tree-whose-names-contain-a-certain
         # delete source files from modules directory
         find ./appdir/usr/ -name '*.cpp' -print0 | xargs -0 -P2 rm

--- a/.github/workflows/appimage-creation.yml
+++ b/.github/workflows/appimage-creation.yml
@@ -93,9 +93,9 @@ jobs:
         # https://github.com/probonopd/go-appimage/blob/master/src/appimagetool/README.md
         wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases/expanded_assets/continuous -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
         chmod +x appimagetool-*.AppImage
-        ./appimagetool-*.AppImage -s deploy appdir/usr/share/applications/*.desktop # Bundle EVERYTHING
+        # ./appimagetool-*.AppImage -s deploy appdir/usr/share/applications/*.desktop # Bundle EVERYTHING
         # or 
-        #./appimagetool-*.AppImage deploy appdir/usr/share/applications/*.desktop # Bundle everything except what comes with the base system
+        ./appimagetool-*.AppImage deploy appdir/usr/share/applications/*.desktop # Bundle everything except what comes with the base system
         # trying to fix issue #1
         rm -v appdir/home/runner/source/OpenSpace/build/modules/webbrowser/ext/cef/cef_binary_102.0.10+gf249b2e+chromium-102.0.5005.115_linux64/Release/libvulkan.so.1
         echo "Check if libvulkan.so.1 files have been excluded  ... "

--- a/.github/workflows/appimage-creation.yml
+++ b/.github/workflows/appimage-creation.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         openSpaceHome="$HOME/source/OpenSpace"
         cd "$openSpaceHome/build"
-        cmake -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/g++-13 -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/gcc-13 -DCMAKE_CXX_STANDARD=20 -DASSIMP_BUILD_MINIZIP=1 -DBUILD_TESTS=OFF -DOPENSPACE_HAVE_TESTS=OFF -DSGCT_BUILD_TESTS=OFF "$openSpaceHome"
+        cmake -DCMAKE_BUILD_TYPE="Release" -DCMAKE_CXX_COMPILER=/usr/bin/g++-13 -DCMAKE_C_COMPILER=/usr/bin/gcc-13 -DCMAKE_CXX_STANDARD=20 -DASSIMP_BUILD_MINIZIP=1 -DBUILD_TESTS=OFF -DOPENSPACE_HAVE_TESTS=OFF -DSGCT_BUILD_TESTS=OFF "$openSpaceHome"
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/appimage-creation.yml
+++ b/.github/workflows/appimage-creation.yml
@@ -80,28 +80,35 @@ jobs:
         mkdir -p appdir/usr/bin ; cp $HOME/source/OpenSpace/bin/OpenSpace_Helper $HOME/source/OpenSpace/bin/OpenSpace ./appdir/usr/bin ; strip ./appdir/usr/bin/*
         mkdir -p appdir/usr/share/applications ; cp ./appdir/OpenSpace.desktop ./appdir/usr/share/applications/
         mkdir -p appdir/usr/share/icons/hicolor/256x256/apps ; cp ./appdir/OpenSpace.png ./appdir/usr/share/icons/hicolor/256x256/apps/
+
         # The OpenSpace executable expects these files in the parent directory of its bin directory
         cp -r $HOME/source/OpenSpace/{config/,modules/,data/,scripts/,shaders/,openspace.cfg} ./appdir/usr/
+
         # patch file created with diff -u openspace.cfg openspace.edited
         patch ./appdir/usr/openspace.cfg < ./appdir/openspacecfg.patch
+
         # https://stackoverflow.com/questionopenspace.cfgs/43412885/fastest-way-to-delete-files-from-a-directory-tree-whose-names-contain-a-certain
         # delete source files from modules directory
         find ./appdir/usr/ -name '*.cpp' -print0 | xargs -0 -P2 rm
         find ./appdir/usr/ -name 'CMakeLists.txt'  -print0 | xargs -0 -P2 rm
         find ./appdir/usr/ -name '*.h' -print0 | xargs -0 -P2 rm
         find ./appdir/usr/ -name '*.cmake' -print0 | xargs -0 -P2 rm
+
         # https://github.com/probonopd/go-appimage/blob/master/src/appimagetool/README.md
         wget -c https://github.com/$(wget -q https://github.com/probonopd/go-appimage/releases/expanded_assets/continuous -O - | grep "appimagetool-.*-x86_64.AppImage" | head -n 1 | cut -d '"' -f 2)
         chmod +x appimagetool-*.AppImage
+
         # ./appimagetool-*.AppImage -s deploy appdir/usr/share/applications/*.desktop # Bundle EVERYTHING
         # or 
         ./appimagetool-*.AppImage deploy appdir/usr/share/applications/*.desktop # Bundle everything except what comes with the base system
+
         # trying to fix issue #1
         rm -v appdir/home/runner/source/OpenSpace/build/modules/webbrowser/ext/cef/cef_binary_102.0.10+gf249b2e+chromium-102.0.5005.115_linux64/Release/libvulkan.so.1
         echo "Check if libvulkan.so.1 files have been excluded  ... "
         find ./appdir -name libvulkan.so.1 
-        # and
-        VERSION=0.20.1p_wot_wolibv ./appimagetool-*.AppImage ./appdir # turn AppDir into AppImage
+
+        # turn AppDir into AppImage
+        VERSION=0.20.1p_wot_wolibv ./appimagetool-*.AppImage ./appdir
 
     - name: Upload AppImage Artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
With these changes, I was able to run a github-built AppImage (using an Ubuntu runner) on my Fedora. I haven't thoroughly tested it - in particular I can't tell whether some modules whose code is only invoked under specific circumstances work or not.

For now, the appimage must be invoked after setting the following env vars:

- `QT_PLUGIN_PATH=lib/x86_64-linux-gnu/qt6/plugins/`
- `OPENSPACE_USER`, set to any *writeable* path you want but a persistent location is recommended
- `OPENSPACE_GLOBEBROWSING`, ditto