### PR TITLE
Enable sccache for faster builds

### DIFF
--- a/.github/workflows/appimage-creation.yml
+++ b/.github/workflows/appimage-creation.yml
@@ -7,6 +7,11 @@ env:
   # This yml is copied from https://github.com/hn-88/OCVWarp/blob/master/.github/workflows/cmake-nix.yml
   # and modified.
   BUILD_TYPE: Release
+  # As recommended here: https://github.com/marketplace/actions/sccache-action
+  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_CACHE_SIZE: 5G
+  CMAKE_C_COMPILER_LAUNCHER: sccache
+  CMAKE_CXX_COMPILER_LAUNCHER: sccache
   
 jobs:
   build:
@@ -54,6 +59,9 @@ jobs:
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt install gcc-13 g++-13
         sudo apt-get install libasound2 libasound2-data libasound2-plugins
+
+    - name: Enable sccache
+      uses: mozilla-actions/sccache-action@v0.0.7
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.


### PR DESCRIPTION
The github action building the appimage went from 48m to 27m, cf. https://github.com/hn-88/OpenSpace-AppImage/actions/workflows/appimage-creation.yml?query=branch%3Asccache

The cache hit rate of the 2nd run is 43% which is much lower than I expected... Upon closer inspection I can see that there are a lot of "Cache write errors". It might be worth understanding what those are.